### PR TITLE
Fix a typo in the pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Other dependencies
 	
 * Method2: Install from PyPI using pip.
 
-	``` $ pip install HiNT-Packages```
+	``` $ pip install HiNT-Package```
 
 * Method3: Install manually 
   1. Install HiNT dependencies


### PR DESCRIPTION
The typo will prevent installing the packages correct if followed. 

See https://pypi.org/project/HiNT-Package/ for the correct installation command.